### PR TITLE
Protect colony mech

### DIFF
--- a/Source/Patches/Pawn.cs
+++ b/Source/Patches/Pawn.cs
@@ -15,6 +15,11 @@ namespace SirRandoo.MSF.Patches
             {
                 return;
             }
+            
+            if (__instance.IsColonyMech)
+            {
+                return;
+            }
 
             if (!__instance.Spawned || __instance.Dead || __instance.Downed)
             {


### PR DESCRIPTION
It should protect colony mechs from death at "solar flare" in case of "Combat Extended" mod was installed.